### PR TITLE
Remove cordova-plugin-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "ecosystem:phonegap"
   ],
   "engines": {
-    "cordova": ">=3.0.0"
+    "cordova": ">=3.0.0",
+    "cordova-android": ">=6.3.0"
   },
   "author": "Adobe PhoneGap Team",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,15 @@
     "ecosystem:phonegap"
   ],
   "engines": {
-    "cordova": ">=3.0.0",
-    "cordova-android": ">=6.3.0"
+    "cordovaDependencies": {
+      "<1.3.0": {
+        "cordova": ">=3.0.0"
+      },
+      "1.3.0": {
+        "cordova": ">=7.1.0",
+        "cordova-android": ">=6.3.0"
+      }
+    }
   },
   "author": "Adobe PhoneGap Team",
   "license": "Apache-2.0",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,9 @@
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="phonegap-plugin-media-stream" version="1.2.1">
   <name>MediaStream</name>
   <dependency id="es6-promise-plugin"/>
-  <dependency id="cordova-plugin-compat" version="^1.1.0"/>
+  <engines>
+      <engine name="cordova-android" version=">=6.3.0" />
+  </engines>
   <platform name="android">
     <js-module src="www/android/MediaDevices.js" name="MediaDevices">
       <clobbers target="navigator.mediaDevices"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the cordova-plugin-compat dependency and set engine tags accordingly to require cordova-android 6.3.0 or newer

## Related Issue

#10 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
cordova-plugin-compat has been integrated into cordova-android 6.3.0, so it's no longer needed and might cause problems with other plugins that already removed the dependency.



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
