### PR TITLE
Fix getUserMedia crash on iOS 9

### DIFF
--- a/src/ios/CDVMediaStream.m
+++ b/src/ios/CDVMediaStream.m
@@ -182,7 +182,7 @@
             NSString *uuid = [[NSUUID UUID] UUIDString];
             [audioTracks setObject:uuid forKey:@"id"];
             [audioTracks setObject:@"audio" forKey:@"kind"];
-            [audioTracks setObject:device.deviceType forKey:@"description"];
+            [audioTracks setObject:device.localizedName forKey:@"label"];
             [arrayAudio addObject:audioTracks];
         }
         [userMedia setObject:arrayAudio forKey:@"audioTracks"];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed deviceType to localizedName as deviceType is not available on iOS 9 and I also think that localizedName might make more sense.
Changed description to label for consistency.

## Related Issue
#14

## Motivation and Context
Fix the crash on iOS 9 and add consistency

## How Has This Been Tested?
Ran tests
Ran it with phonegap-plugin-image-capture and checked that it continues working

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
