### PR TITLE
Fix iOS 9 crashes and add consistency

### DIFF
--- a/src/ios/CDVMediaStream.m
+++ b/src/ios/CDVMediaStream.m
@@ -33,10 +33,14 @@
     NSArray *devices = [AVCaptureDevice devices];
     for (AVCaptureDevice *device in devices) {
         NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:5];
-        NSLog(@"%@", device.deviceType);
-        NSLog(@"%@", device.description);
-        [dict setObject:device.deviceType forKey:@"kind"];
-        [dict setObject:device.description forKey:@"label"];
+        NSString *kind = @"audio";
+        if ([[AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo] containsObject:device]) {
+            kind = @"video";
+        }
+        NSLog(@"%@", kind);
+        NSLog(@"%@", device.localizedName);
+        [dict setObject:kind forKey:@"kind"];
+        [dict setObject:device.localizedName forKey:@"label"];
         [dict setObject:@"undefined" forKey:@"deviceID"];
         [dict setObject:@"undefined" forKey:@"groupID"];
         [array addObject:dict];
@@ -181,7 +185,7 @@
             NSMutableDictionary *audioTracks = [NSMutableDictionary dictionaryWithCapacity:5];
             [audioTracks setObject:device.uniqueID forKey:@"id"];
             [audioTracks setObject:@"audio" forKey:@"kind"];
-            [audioTracks setObject:device.deviceType forKey:@"label"];
+            [audioTracks setObject:device.localizedName forKey:@"label"];
             [audioTracks setObject: [NSNumber numberWithBool:YES] forKey:@"enabled"];
             [audioTracks setObject:[NSNumber numberWithBool:NO] forKey:@"muted"];
             [audioTracks setObject:@"live" forKey:@"readyState"];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change device.deviceType to device.localizedName as it's available on iOS 9 and makes more sense as label should be a device name.
Changed enumerateDevices to set the kind to audio or video instead of to device.deviceType

## Related Issue
#15 
#14 

## Motivation and Context
The plugin is crashing on iOS 9 and kind is not consisten on what returns. This PR addresses both things.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
