### PR TITLE
Issue9

### DIFF
--- a/www/mediadevices.js
+++ b/www/mediadevices.js
@@ -95,5 +95,6 @@ mediaDevices.getUserMedia = function (constraints) {
         }
     });
 };
-
+mediaDevices.getSupportedConstraints();
+mediaDevices.enumerateDevices();
 module.exports = mediaDevices;

--- a/www/mediadevices.js
+++ b/www/mediadevices.js
@@ -51,6 +51,7 @@ mediaDevices.getSupportedConstraints = function () {
         return this._supportedConstraints;
     } else {
         exec(successConstraints, null, 'Stream', 'getSupportedConstraints', []);
+        return this._supportedConstraints;
     }
 };
 
@@ -65,6 +66,7 @@ mediaDevices.enumerateDevices = function () {
             resolve(that._devices);
         } else {
             exec(successDevices, null, 'Stream', 'enumerateDevices', []);
+            resolve(that._devices);
         }
     });
 };


### PR DESCRIPTION
Fetch data about devices and constraints when mediaDevices is created.

## Description
This change pre-fetches the data provided by the mediaDevices.enumerateDevices() and mediaDevices.getSupportedConstraints when the mediaDevices object is created

## Related Issue
Issue #9 

## Motivation and Context
This change pre-fetches the data provided by the mediaDevices.enumerateDevices() and mediaDevices.getSupportedConstraints when the mediaDevices object is created. This ends the delay in fetching this data later on when a user requests for it.

## How Has This Been Tested?
Tested with pre existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
